### PR TITLE
Fixed low quality of thumnails

### DIFF
--- a/app/code/community/Aoe/AmazonCdn/Model/Varien/Gd2.php
+++ b/app/code/community/Aoe/AmazonCdn/Model/Varien/Gd2.php
@@ -52,7 +52,7 @@ class Aoe_AmazonCdn_Model_Varien_Gd2 extends Varien_Image_Adapter_Gd2
         $cachedData  = $this->_getHelper()->getCacheFacade()->get($filename);
         if ($cachedData && is_array($cachedData)) {
             $this->_fileInCache    = true;
-            $this->_fileType       = $cachedData['image_type'];
+            $this->_fileType       = (int)$cachedData['image_type'];
             $this->_fileMimeType   = image_type_to_mime_type($this->_fileType);
             $this->_imageSrcWidth  = $cachedData['image_width'];
             $this->_imageSrcHeight = $cachedData['image_height'];


### PR DESCRIPTION
In this file lib/Varien/Image/Adapter/Gd2.php in line 314, file type is strictly compared to int constants

```
if ((IMAGETYPE_GIF === $fileType) || (IMAGETYPE_PNG === $fileType)) {
```

We have to make sure that  `$this->_fileType` is always int.

This path solved issue when thumbnail is generated in low quality (because of the true color is not being set)